### PR TITLE
CI skip Initial update

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -6,6 +6,13 @@ if "%ARCH%"=="32" (
 
 @REM Install Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre
 START /WAIT "" "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe" modify --installPath "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools" --passive --add Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre
+
+@REM Install dot NET core 2.1.818 using dotnet-install scripts
+curl -L -o %BUILD_PREFIX%/dotnet-install.ps1 https://dot.net/v1/dotnet-install.ps1
+powershell %BUILD_PREFIX%/dotnet-install.ps1 -InstallDir %BUILD_PREFIX%/dotnet -Version 2.1.818
+set PATH=%BUILD_PREFIX%/dotnet;%BUILD_PREFIX%\dotnet\sdk\2.1.818;%PATH%
+set MSBuildSDKsPath=%BUILD_PREFIX%\dotnet\sdk\2.1.818\Sdks
+
 msbuild.exe /p:Platform=%PLATFORM% /p:Configuration=Release
 
 for /r %SRC_DIR%\out\Release-%PLATFORM% %%f in (*.exe) do @copy "%%f" %LIBRARY_BIN%

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -4,6 +4,8 @@ if "%ARCH%"=="32" (
     set PLATFORM=x64
 )
 
+@REM Install Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre
+START /WAIT "" "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe" modify --installPath "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools" --passive --add Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre
 msbuild.exe /p:Platform=%PLATFORM% /p:Configuration=Release
 
 for /r %SRC_DIR%\out\Release-%PLATFORM% %%f in (*.exe) do @copy "%%f" %LIBRARY_BIN%

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -13,6 +13,17 @@ powershell %BUILD_PREFIX%/dotnet-install.ps1 -InstallDir %BUILD_PREFIX%/dotnet -
 set PATH=%BUILD_PREFIX%/dotnet;%BUILD_PREFIX%\dotnet\sdk\2.1.818;%PATH%
 set MSBuildSDKsPath=%BUILD_PREFIX%\dotnet\sdk\2.1.818\Sdks
 
+@REM Install WDK: Requires Admin rights
+@REM Find WDK URL for this version of Windows. In this case, 1809:
+@REM https://learn.microsoft.com/en-us/windows-hardware/drivers/other-wdk-downloads
+curl -L -o wdksetup.exe https://download.microsoft.com/download/1/4/0/140EBDB7-F631-4191-9DC0-31C8ECB8A11F/wdk/wdksetup.exe
+START /WAIT wdksetup.exe /features + /q
+
+@REM Hack to make WDK compatible with Visual Studio Build Tools
+@REM See: https://social.msdn.microsoft.com/Forums/en-US/efe5f9f8-c32d-4a25-87e2-abbe711dadbb/no-wdk-support-for-visual-studio-2017-build-tools?forum=wdk
+7z x "C:\Program Files (x86)\Windows Kits\10\Vsix\WDK.vsix" -o%BUILD_PREFIX%\WDK
+robocopy "%BUILD_PREFIX%\WDK\$VCTargets" "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\Common7\IDE\VC\VCTargets" /s /e *.*
+
 msbuild.exe /p:Platform=%PLATFORM% /p:Configuration=Release
 
 for /r %SRC_DIR%\out\Release-%PLATFORM% %%f in (*.exe) do @copy "%%f" %LIBRARY_BIN%

--- a/recipe/conda-build.patch
+++ b/recipe/conda-build.patch
@@ -1,8 +1,8 @@
 diff --git a/Directory.Build.props b/Directory.Build.props
-index 3177de8..d8a6dc0 100644
+index 3177de8..15b009f 100644
 --- a/Directory.Build.props
 +++ b/Directory.Build.props
-@@ -109,12 +109,12 @@
+@@ -109,13 +109,13 @@
    </PropertyGroup>
  
    <PropertyGroup>
@@ -13,7 +13,9 @@ index 3177de8..d8a6dc0 100644
    <PropertyGroup>
      <OutputPath>$(StagingOutputRootPath)$(MSBuildProjectName)\</OutputPath>
 -    <VCToolsVersion>14.15.26726</VCToolsVersion>
+-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
 +    <VCToolsVersion>14.16.27023</VCToolsVersion>
-     <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
++    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
      <PlatformToolset>v141</PlatformToolset>
      <OutDir>$(OutputPath)</OutDir>
+     <O>$(Platform)\$(Configuration)</O>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - {{ compiler('cxx') }}
     - {{ compiler('c') }}
     - {{ compiler('m2w64_fortran') }}
+    - perl
   run:
     - mpi 1.0 msmpi
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,3 +1,35 @@
+# -----------------------------------------------------------------------------
+#  *** Important ****
+# This package currently needs to be built manually. There are build tools injected
+# into the Visual Studio toolchain that have the potential to mess up builders.
+# Once the appropriate versions of WDK, .NET core, and VC++ 2017 version 15.9 v14.16 Libs for Spectre (x86 and x64)
+# have been added to the Windows builder image, this reccipe will need to be modified.
+# 
+# When Building This package:
+# - Take care to create PRs with "CI skip" in the title.
+#     - This will cause CI to not run on PR creation, new commits, OR on final merge
+#     - See https://github.com/AnacondaRecipes/msmpi-feedstock/pull/1 for an example
+# 
+# Building on a dev instace:
+# https://github.com/anaconda-distribution/perseverance-skills/blob/8c2c9dd826416c0f4695097528c8952373431bb6/sections/Package_building/More_debugging/Dev_machine_instances.md#initializing-an-ec2-instance
+# 
+# 1. Spin up a Windows dev instance per the instructions above. GUI instance may be helpful.
+# 2. Right click "Anaconda Prompt (miniconda3)" in the start menu
+# 3. Select more->Run as Administrator
+# 4. `conda create -n build git m2-base conda-build conda-package-handling`
+# 5. `conda activate build`
+# 6. `cd C:\Users\dev-admin\Desktop`
+# 7. `git clone https://github.com/AnacondaRecipes/aggregate.git`
+# 8. `cd aggregate`
+# 9. `git submodule update --init msmpi-feedstock`
+# 10. `cd msmpi-feedstock && git checkout {{YOUR_BRANCH}} && cd ..`
+# 11. `conda build msmpi-feedstock --croot ../croot`
+# 12. Ensure build was successfull
+# 13. `cd ..`
+# 14. `cp ./croot/win-64/msmpi-*.tar.bz2 .`
+# 15. cph transmute msmpi-*.tar.bz2 .conda
+# ------------------------------------------------------------------------------
+
 {% set name = "msmpi" %}
 {% set version = "10.1.1" %}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - {{ compiler('m2w64_fortran') }}
     - perl
     - 7zip
+    - m2-patch  # [win]
   run:
     - mpi 1.0 msmpi
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,8 +21,9 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('m2w64_fortran') }}
     - perl
-  run:
-    - mpi 1.0 msmpi
+    - 7zip
+  # run:
+  #   - mpi 1.0 msmpi
 
 test:
   files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,8 +22,8 @@ requirements:
     - {{ compiler('m2w64_fortran') }}
     - perl
     - 7zip
-  # run:
-  #   - mpi 1.0 msmpi
+  run:
+    - mpi 1.0 msmpi
 
 test:
   files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - conda-build.patch
 
 build:
-  number: 7
+  number: 0
   skip: true  # [not win]
 
 requirements:
@@ -81,6 +81,7 @@ about:
   home: https://docs.microsoft.com/en-us/message-passing-interface/microsoft-mpi
   license: MIT
   license_file: LICENSE.txt
+  license_family: MIT
   summary: Microsoft message-passing-interface (MS-MPI)
   description: |
     Microsoft MPI (MS-MPI) is a Microsoft implementation of the Message Passing

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -111,7 +111,7 @@ test:
     - mpiexec.exe -n 4 helloworld.exe
 
 about:
-  home: https://docs.microsoft.com/en-us/message-passing-interface/microsoft-mpi
+  home: https://learn.microsoft.com/en-us/message-passing-interface/microsoft-mpi
   license: MIT
   license_file: LICENSE.txt
   license_family: MIT
@@ -120,7 +120,7 @@ about:
     Microsoft MPI (MS-MPI) is a Microsoft implementation of the Message Passing
     Interface standard for developing and running parallel applications on the
     Windows platform.
-  doc_url: https://docs.microsoft.com/en-us/message-passing-interface/microsoft-mpi
+  doc_url: https://learn.microsoft.com/en-us/message-passing-interface/microsoft-mpi
   dev_url: https://github.com/microsoft/Microsoft-MPI
 
 extra:


### PR DESCRIPTION
# MSMPI 10.1.1
upstream: https://github.com/microsoft/Microsoft-MPI/tree/v10.1.1
License: https://github.com/microsoft/Microsoft-MPI/blob/master/LICENSE.txt
Requirements: https://github.com/microsoft/Microsoft-MPI/tree/v10.1.1#prerequisites

## Notes
- This package is a dependency of [mpi4py](https://github.com/AnacondaRecipes/mpi4py-feedstock) to support Windows. This is a high priority package.
- The Windows builder image does not currently have the dependencies necessary to build this package. **This package must be built manually** at the moment. See `meta.yaml` for more info.
- Jira tickets will be created for the project of adding WDK, Spectre Libs, and .NET Core build tools to the Windows builder image
- Attached are the build artifacts and build log

## Changes
- Fork from CF
- Reset build number
- Update about section
- Update patch to match our build env
- Modify build script to:
    - Install VC++ 2017 version 15.9 v14.16 Libs for Spectre (x86 and x64)
    - Install Windows Driver Kit (WDK) and patch for `Visual Studio Build Tools`
    - Use `dotnet-install.ps1`: Microsoft's script for install .Net Core in a CI ENV 
    
    
[msmpi-feedstock_artifacts_and_log.zip](https://github.com/AnacondaRecipes/msmpi-feedstock/files/10240494/msmpi-feedstock_artifacts_and_log.zip)
